### PR TITLE
Diesel pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 actix-web = "2"
 actix-rt = "1"
 
-diesel = { version = "1.4.3", features = ["postgres"] }
+diesel = { version = "1.4.3", features = ["postgres","r2d2"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/migrations/create_sets/up.sql
+++ b/migrations/create_sets/up.sql
@@ -1,35 +1,35 @@
 CREATE TABLE IF NOT EXISTS sets (
-    id Integer PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
     exercise_id int,
     style varchar not null,
     unit varchar not null,
     goal_reps smallint not null ,
     goal_value varchar not null ,
     description varchar not null,
-    created_or_completed timestamp not null ,
-    completed_reps smallint not null,
-    completed_value varchar not null
+    created_or_completed timestamp not null DEFAULT NOW(),
+    completed_reps smallint not null DEFAULT 0,
+    completed_value varchar not null DEFAULT ''
 );
 
 
 
 CREATE TABLE IF NOT EXISTS exercises(
-    id INTEGER PRIMARY KEY ,
+    id SERIAL PRIMARY KEY ,
     origin_id INTEGER not null,
     set_id INTEGER  not NULL,
     fname varchar not null,
     exercise_type INTEGER not null,
     description varchar not null,
     notes varchar  not null,
-    create_time timestamp not null,
-    complete_time timestamp not null,
+    create_time timestamp not null DEFAULT NOW(),
+    complete_time timestamp not null DEFAULT NOW(),
     create_id INTEGER not null,
     completed_id INTEGER not null
 );
 
 
 CREATE  TABLE  IF NOT EXISTS users(
-    id INTEGER PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
     username varchar not null,
     fname varchar not null,
     email varchar not null,
@@ -37,14 +37,14 @@ CREATE  TABLE  IF NOT EXISTS users(
 );
 
 CREATE TABLE IF NOT EXISTS workouts (
-    id INTEGER PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
     origin_id integer not null,
     exercise INTEGER not null,
     fname varchar not null,
     description varchar not null,
     notes varchar not null ,
-    created_time timestamp not null,
-    completed_time timestamp not null  ,
+    created_time timestamp not null DEFAULT NOW(),
+    completed_time timestamp not null DEFAULT NOW(),
     create_id integer not null,
     completed_id integer not null
 );

--- a/src/models/exercises.rs
+++ b/src/models/exercises.rs
@@ -2,9 +2,8 @@
 
 use serde::{Serialize, Deserialize};
 use std::time::SystemTime;
-use diesel::RunQueryDsl;
+use diesel::{PgConnection,RunQueryDsl};
 use crate::schema::exercises;
-use crate::establish_connection;
 use diesel::query_dsl::filter_dsl::FindDsl;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable)]
@@ -25,7 +24,6 @@ pub struct Exercise {
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Insertable)]
 #[table_name = "exercises"]
 pub struct NewExercise {
-    pub id: i32,
     pub origin_id: i32,
     pub set_id: i32,
     pub fname: String,
@@ -40,19 +38,16 @@ pub struct NewExercise {
 
 
 impl NewExercise {
-    //todo: agree on method names
-    pub fn create(&self) -> Result<Exercise, diesel::result::Error> {
-        let connection = establish_connection();
+    pub fn create(&self, connection: &PgConnection) -> Result<Exercise, diesel::result::Error> {
         diesel::insert_into(exercises::table)
             .values(self)
-            .get_result(&connection)
+            .get_result(connection)
     }
 }
 
 impl Exercise {
-    pub fn get_exercise_by_id(id: i32) -> Result<Exercise, diesel::result::Error> {
-        let conn = establish_connection();
-        exercises::table.find(id).get_result(&conn)
+    pub fn get_exercise_by_id(id: i32, conn: &PgConnection) -> Result<Exercise, diesel::result::Error> {
+        exercises::table.find(id).get_result(conn)
     }
 }
 
@@ -79,7 +74,6 @@ mod tests {
 
         let t_exercise = Exercise {
             id: t_id,
-
             origin_id: t_origin_id,
             set_id: t_set_id,
             fname: t_fname.to_string(),

--- a/src/models/sets.rs
+++ b/src/models/sets.rs
@@ -28,7 +28,6 @@ pub struct NewSet {
     pub goal_reps: i16,
     pub goal_value: String,
     pub description: String,
-    pub created_or_completed: SystemTime,
 }
 
 impl NewSet {
@@ -55,7 +54,7 @@ mod tests {
     use crate::models::sets::Set;
 
     #[test]
-    fn test_new_set(){
+    fn test_set(){
         let t_id = 10;
         let t_exercise_id = 100;
         let t_style = "Fancy";

--- a/src/models/sets.rs
+++ b/src/models/sets.rs
@@ -3,8 +3,9 @@ use std::time::SystemTime;
 
 use crate::schema::sets;
 use diesel::query_dsl::filter_dsl::FindDsl;
+use diesel::PgConnection;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Insertable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable)]
 pub struct Set {
     pub id: i32,
     pub exercise_id: Option<i32>,
@@ -18,10 +19,9 @@ pub struct Set {
     pub completed_value: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Insertable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[table_name = "sets"]
 pub struct NewSet {
-    pub id: i32,
     pub exercise_id:i32,
     pub style: String,
     pub unit: String,
@@ -29,28 +29,23 @@ pub struct NewSet {
     pub goal_value: String,
     pub description: String,
     pub created_or_completed: SystemTime,
-    pub completed_reps: i16,
-    pub completed_value: String,
 }
 
 impl NewSet {
-    pub fn create(&self) -> Result<Set, diesel::result::Error> {
+    pub fn create(&self, connection: &PgConnection) -> Result<Set, diesel::result::Error> {
         use diesel::RunQueryDsl;
-        use crate::establish_connection;
 
-        let connection = establish_connection();
         diesel::insert_into(sets::table)
             .values(self)
-            .get_result(&connection)
+            .get_result(connection)
     }
 }
 
 impl Set {
-    pub fn get_set_by_id(id: i32) ->Result<Set, diesel::result::Error>{
+    pub fn get_set_by_id(id: i32, conn: &PgConnection) ->Result<Set, diesel::result::Error>{
         use diesel::RunQueryDsl;
-        use crate::establish_connection;
-        let conn = establish_connection();
-        sets::table.find(id).get_result(&conn)
+
+        sets::table.find(id).get_result(conn)
     }
 }
 

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -19,7 +19,6 @@ pub struct User {
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Insertable)]
 #[table_name="users"]
 pub struct NewUser {
-    pub id: i32,
     pub username: String,
     pub fname: String,
     pub email: String,
@@ -37,7 +36,9 @@ impl User {
 
         users::table.find(id).get_result(conn)
     }
+}
 
+impl NewUser {
     pub fn create(&self, connection: &PgConnection) -> Result<User, diesel::result::Error> {
         use diesel::RunQueryDsl;
 

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -5,6 +5,7 @@ use serde::{Serialize, Deserialize};
 use mockall::predicate::*;
 
 use crate::schema::users;
+use diesel::PgConnection;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Insertable)]
 pub struct User {
@@ -30,38 +31,31 @@ pub struct NewUser {
 
 
 impl User {
-    pub fn get_user (id: i32) -> Result<User, diesel::result::Error> {
+    pub fn get_user (id: i32, conn: &PgConnection) -> Result<User, diesel::result::Error> {
         use diesel::QueryDsl;
         use diesel::RunQueryDsl;
-        use crate::establish_connection;
 
-        let conn = establish_connection();
-        users::table.find(id).get_result(&conn)
+        users::table.find(id).get_result(conn)
     }
 
-    pub fn create(&self) -> Result<User, diesel::result::Error> {
+    pub fn create(&self, connection: &PgConnection) -> Result<User, diesel::result::Error> {
         use diesel::RunQueryDsl;
-        use crate::establish_connection;
 
-        let connection = establish_connection();
         diesel::insert_into(users::table)
             .values(self)
-            .get_result(&connection)
+            .get_result(connection)
     }
 }
 
 
 impl UserList {
-    pub fn get_users() -> Self {
+    pub fn get_users(conn: &PgConnection) -> Self {
 
         use diesel::RunQueryDsl;
-        use crate::establish_connection;
         use crate::schema::users::dsl::*;
 
-        let conn = establish_connection();
-
         let results = users
-            .load::<User>(&conn)
+            .load::<User>(conn)
             .expect("Error retreiving users");
 
         UserList(results)

--- a/src/models/workouts.rs
+++ b/src/models/workouts.rs
@@ -2,8 +2,7 @@ use serde::{Serialize, Deserialize};
 use std::time::SystemTime;
 
 use crate::schema::workouts;
-use diesel::RunQueryDsl;
-use crate::establish_connection;
+use diesel::{PgConnection,RunQueryDsl};
 use diesel::query_dsl::filter_dsl::FindDsl;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable)]
@@ -23,7 +22,6 @@ pub struct Workout {
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Insertable)]
 #[table_name="workouts"]
 pub struct NewWorkout {
-    pub id: i32,
     pub origin_id: i32,
     pub exercise: i32,
     pub fname: String,
@@ -36,21 +34,18 @@ pub struct NewWorkout {
 }
 
 impl NewWorkout{
-    pub fn create(&self)->Result<Workout, diesel::result::Error>
+    pub fn create(&self, conn: &PgConnection)->Result<Workout, diesel::result::Error>
     {
-        use crate::establish_connection;
-        let conn = establish_connection();
         diesel::insert_into(workouts::table)
             .values(self)
-            .get_result(&conn)
+            .get_result(conn)
     }
 }
 
 
 impl Workout{
-    pub fn get_workout_by_id(id:i32) ->Result<Workout, diesel::result::Error>{
-        let conn = establish_connection();
-       workouts::table.find(id).get_result(&conn)
+    pub fn get_workout_by_id(id:i32, conn: &PgConnection) ->Result<Workout, diesel::result::Error>{
+       workouts::table.find(id).get_result(conn)
     }
 
 }

--- a/tests/integration_test_sets.rs
+++ b/tests/integration_test_sets.rs
@@ -37,7 +37,6 @@ mod tests {
             goal_reps: t_goal_reps,
             goal_value: t_goal_value.to_string(),
             description: t_description.to_string(),
-            created_or_completed: t_created_or_completed,
         };
 
         match ns.create(&conn) {

--- a/tests/integration_test_sets.rs
+++ b/tests/integration_test_sets.rs
@@ -4,15 +4,17 @@
 
 extern crate diesel;
 extern crate dotenv;
+
+
 mod tests {
-    use DED_backend::{establish_connection};
+    use DED_backend::establish_connection;
     use DED_backend::models::sets::{Set, NewSet};
     use diesel::RunQueryDsl;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn test_db_set_insert_and_find() {
-        let conn = establish_connection();
+        let conn = establish_connection().get().unwrap();
         let _xxx = diesel::delete(DED_backend::schema::sets::dsl::sets)
             .execute(&conn);
 
@@ -29,32 +31,27 @@ mod tests {
         let t_completed_value = "Should this be a string";
 
         let ns = NewSet {
-            id: t_id,
             exercise_id: t_exercise_id,
             style: t_style.to_string(),
             unit: t_unit.to_string(),
             goal_reps: t_goal_reps,
             goal_value: t_goal_value.to_string(),
             description: t_description.to_string(),
-            completed_reps: t_completed_reps,
             created_or_completed: t_created_or_completed,
-            completed_value: t_completed_value.to_string()
         };
 
-        let result = ns.create();
-
-        match result {
+        match ns.create(&conn) {
             Ok(u) => {
                 assert_eq!(u.unit, t_unit);
             }
             Err(E) => {
-                assert_eq!(1, 5);
                 print!("got error {}", E);
+                assert_eq!(1, 5);
                 // assert_eq!(E, diesel::ConnectionError::CouldntSetupConfiguration);     Need a proper error for this
             }
         }
 
-        let result = Set::get_set_by_id(t_id);
+        let result = Set::get_set_by_id(t_id, &conn);
 
         match result{
             Ok(r_set) =>{
@@ -82,8 +79,8 @@ mod tests {
 
     #[test]
     fn test_db_set_not_found(){
-        let result = Set::get_set_by_id(-999);
-        match result{
+        let conn = establish_connection().get().unwrap();
+        match Set::get_set_by_id(-999, &conn) {
             Ok(_T) =>{
                 print!("Negative value in sets ");
                 assert_eq!(6,-1);

--- a/tests/integration_test_users.rs
+++ b/tests/integration_test_users.rs
@@ -4,7 +4,7 @@ extern crate diesel;
 extern crate dotenv;
 mod tests {
     use DED_backend::establish_connection;
-    use DED_backend::models::users::{User,UserList};
+    use DED_backend::models::users::{User,UserList,NewUser};
 
     use diesel::RunQueryDsl;
 
@@ -18,57 +18,44 @@ mod tests {
         let _xxx = diesel::delete(DED_backend::schema::users::dsl::users)
             .execute(&conn);
 
-        // assert_eq!(xxx,Ok(0));
-
-        let t_id = 1999;
         let t_uname = "TestUser";
         let t_fname = "Usable User";
         let t_email = "testuser@testdomain.com";
         let t_salt = "some_like_MSG";
 
-        // let t_user = User(&conn, &t_id, &t_uname, &t_fname, &t_email, &t_salt);
-
-        let t_user = User {
-            id: t_id,
+        let t_user = NewUser {
             username: t_uname.to_string(),
             fname: t_fname.to_string(),
             email: t_email.to_string(),
             salt: t_salt.to_string()
         };
 
-
-
-        let result = t_user.create(&conn);
-
-        match result {
+        let new_user_id = match t_user.create(&conn) {
             Ok(r_user) => {
-                assert_eq!(t_id, r_user.id);
                 assert_eq!(t_uname, r_user.username);
                 assert_eq!(t_fname, r_user.fname);
                 assert_eq!(t_email, r_user.email);
                 assert_eq!(t_salt, r_user.salt);
+                r_user.id
             }
             Err(E) => {//todo: need to fix this
                 assert_eq!(1,5);
                 print!("got error {}",E);
                 // assert_eq!(E, diesel::ConnectionError::CouldntSetupConfiguration);
+                0
             }
         };
 
-
-
-        let result = User::get_user(t_id, &conn);
-
-        match result{
+        match User::get_user(new_user_id, &conn) {
             Ok(r_user) =>{
-                assert_eq!(t_id, r_user.id);
+                assert_eq!(new_user_id, r_user.id);
                 assert_eq!(t_uname,r_user.username);
                 assert_eq!(t_fname, r_user.fname);
                 assert_eq!(t_email, r_user.email);
                 assert_eq!(t_salt, r_user.salt);
             }
             Err(E) =>{
-                assert_eq!(E,diesel::NotFound);
+                assert_eq!(E, diesel::NotFound);
             }
         }
 
@@ -103,24 +90,21 @@ mod tests {
     #[test]
     fn test_db_user_list(){  //todo:  need to complete this !!!
         let conn = establish_connection().get().unwrap();
-        let user_1 = User{
-            id: 100,
+        let user_1 = NewUser{
             username: "user 100".to_string(),
             fname: "Weak".to_string(),
             email: "dfsff@2123.com".to_string(),
             salt: "MSG001".to_string()
         };
 
-        let user_2 = User{
-            id: 200,
+        let user_2 = NewUser{
             username: "user 200".to_string(),
             fname: "Weak2".to_string(),
             email: "dfsff@21232.com".to_string(),
             salt: "MSG0201".to_string()
         };
 
-        let user_3 = User{
-            id: 300,
+        let user_3 = NewUser{
             username: "user 300".to_string(),
             fname: "Weak3".to_string(),
             email: "d3fsff@212532.com".to_string(),

--- a/tests/integration_test_users.rs
+++ b/tests/integration_test_users.rs
@@ -3,17 +3,16 @@
 extern crate diesel;
 extern crate dotenv;
 mod tests {
-    use DED_backend::{establish_connection};
+    use DED_backend::establish_connection;
     use DED_backend::models::users::{User,UserList};
 
     use diesel::RunQueryDsl;
-    
 
     // to run all tests sequentially    cargo test -- --test-threads=1
     #[test]
     fn test_db_user_insert_and_find() {
     // NOTE: these two tests are run sequentially since multi thread test might create a race cond.
-        let conn = establish_connection();
+        let conn = establish_connection().get().unwrap();
 
         // delete all entries in the database
         let _xxx = diesel::delete(DED_backend::schema::users::dsl::users)
@@ -39,7 +38,7 @@ mod tests {
 
 
 
-        let result = t_user.create();
+        let result = t_user.create(&conn);
 
         match result {
             Ok(r_user) => {
@@ -58,7 +57,7 @@ mod tests {
 
 
 
-        let result = User::get_user(t_id);
+        let result = User::get_user(t_id, &conn);
 
         match result{
             Ok(r_user) =>{
@@ -78,7 +77,8 @@ mod tests {
 
     #[test]
     fn test_db_user_not_found(){
-        let result = User::get_user(-99);
+        let conn = establish_connection().get().unwrap();
+        let result = User::get_user(-99, &conn);
 
         match result{//todo: need to fix this
             Err(E) =>{
@@ -102,6 +102,7 @@ mod tests {
 
     #[test]
     fn test_db_user_list(){  //todo:  need to complete this !!!
+        let conn = establish_connection().get().unwrap();
         let user_1 = User{
             id: 100,
             username: "user 100".to_string(),
@@ -126,14 +127,11 @@ mod tests {
             salt: "MSG30201".to_string()
         };
 
-        user_1.create();
-        user_2.create();
-        user_3.create();
+        user_1.create(&conn);
+        user_2.create(&conn);
+        user_3.create(&conn);
 
-        let _u_list = UserList::get_users();
+        let _u_list = UserList::get_users(&conn);
 
     }
-
-
-
 }

--- a/tests/integration_test_workouts.rs
+++ b/tests/integration_test_workouts.rs
@@ -14,7 +14,7 @@ mod tests {
     // to run all tests sequentially    cargo test -- --test-threads=1
     #[test]
     fn test_db_workout_insert_and_find() {
-        let conn = establish_connection();
+        let conn = establish_connection().get().unwrap();
 
         let _xxx = diesel::delete(DED_backend::schema::workouts::dsl::workouts)
             .execute(&conn);
@@ -32,7 +32,6 @@ mod tests {
         let t_completed_id = 666;
 
         let t_workout = NewWorkout {
-            id: t_id,
             origin_id: t_origin_id,
             exercise: t_exercise,
             fname: t_fname.to_string(),
@@ -45,10 +44,8 @@ mod tests {
         };
 
 
-        let res = t_workout.create();
-        match res {
+        match t_workout.create(&conn) {
             Ok(r) => {
-                assert_eq!(r.id, t_id);
                 assert_eq!(r.origin_id, t_origin_id);
                 assert_eq!(r.exercise, t_exercise);
                 assert_eq!(r.description, t_description);
@@ -71,9 +68,7 @@ mod tests {
             }
         }
 
-        let res = Workout::get_workout_by_id(t_id);
-
-        match res {
+        match Workout::get_workout_by_id(t_id,&conn) {
             Ok(r) => {
                 assert_eq!(r.id, t_id);
                 assert_eq!(r.origin_id, t_origin_id);
@@ -100,7 +95,8 @@ mod tests {
 
     #[test]
     fn test_db_workout_not_found(){
-        let res = Workout::get_workout_by_id(-99999);
+        let conn = establish_connection().get().unwrap();
+        let res = Workout::get_workout_by_id(-99999, &conn);
         match res{//todo: need to fix this
             Err(E) =>{
                 assert_eq!(E, diesel::NotFound);

--- a/tests/integration_tests_exercises.rs
+++ b/tests/integration_tests_exercises.rs
@@ -5,22 +5,22 @@ extern crate dotenv;
 
 
 mod tests {
-    use DED_backend::{establish_connection};
+    use DED_backend::establish_connection;
     use DED_backend::models::exercises::{Exercise, NewExercise};
     use diesel::RunQueryDsl;
-    
+
     use std::time::{SystemTime,UNIX_EPOCH};
     use std::time::Duration;
-    
+
     #[test]
     fn test_db_exercise_insert_and_find(){
-        let conn = establish_connection();
+        let conn = establish_connection().get().unwrap();
 
         // delete all entries in the database
         let _xxx = diesel::delete(DED_backend::schema::exercises::dsl::exercises)
             .execute(&conn);
 
-        let t_id= 100;
+        let t_id= 1;
         let t_origin_id= 200;
         let t_set_id= 300;
         let t_fname= "SuperJock";
@@ -31,7 +31,7 @@ mod tests {
         let t_complete_time= t_create_time + Duration::new(1200,0);
         let t_create_id=100;
         let t_completed_id= 240;
-        
+
         let t_exercise = Exercise{
             id: t_id,
             origin_id: t_origin_id,
@@ -48,7 +48,6 @@ mod tests {
 
 
         let new_ex = NewExercise{
-            id: t_id,
             origin_id: t_origin_id,
             set_id: t_set_id,
             fname: t_fname.to_string(),
@@ -62,9 +61,7 @@ mod tests {
         };
 
 
-        let result = new_ex.create();
-
-        match result{
+        match new_ex.create(&conn) {
             Ok(r_ex) =>{
                 assert_eq!(r_ex.id, t_exercise.id);
                 assert_eq!(r_ex.origin_id, t_exercise.origin_id);
@@ -94,8 +91,7 @@ mod tests {
             }
         }
 
-        let result = Exercise::get_exercise_by_id(t_id);
-        match result {
+        match Exercise::get_exercise_by_id(t_id, &conn) {
             Err(E) =>{
                 assert_eq!(E,diesel::NotFound );
             }
@@ -127,8 +123,8 @@ mod tests {
     }
     #[test]
     fn test_db_exercises_not_found(){
-        let result = Exercise::get_exercise_by_id(-123923);
-        match result{ //todo: need to fix this.
+        let conn = establish_connection().get().unwrap();
+        match Exercise::get_exercise_by_id(-123923, &conn) {
             Err(E) =>{
                 assert_eq!(E, diesel::NotFound);
             }

--- a/tests/test_set_handler.rs
+++ b/tests/test_set_handler.rs
@@ -2,7 +2,7 @@
 
 mod tests {
     use DED_backend::handlers::set;
-    use actix_web::{web, test, App};
+    use actix_web::{web, test, App, http::StatusCode};
 
     #[actix_rt::test]
     async fn test_set_new() {
@@ -11,8 +11,6 @@ mod tests {
                 .route("/sets/new/", web::post().to(set::new))
         )
         .await;
-
-        // NEED SOME CHANGES HERE
 
         let payload = "{
             \"exercise_id\": -1,
@@ -31,8 +29,7 @@ mod tests {
                   .set_payload(payload)
                   .to_request();
 
-        let _resp = test::call_service(&mut app, req).await;
-        // Need some changes here        // assert_eq!(resp.status(), StatusCode::OK);
+        let resp = test::call_service(&mut app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
     }
-
 }


### PR DESCRIPTION
These changes where made to start using the diesel r2d2 connection pooling.

Some of the big changes are now the database connection is built into the handler functions as well as the diesel methods. You can look into the various `create` methods for example of use. As well as the tests for how to continue to make those.

Database changes are important. The start to add defaults for the various columns. This will allow the various NEW datatype to work on insert.

Some of the tests needed to be changed slightly as we can no longer reliably test ID's from the various inserts (yay state changes).

Outside of these changes, no logic changes have really been made. 