### PR TITLE
Get sets by

### DIFF
--- a/src/appconfig.rs
+++ b/src/appconfig.rs
@@ -24,6 +24,10 @@ pub fn config_app(cfg: &mut web::ServiceConfig) {
                     web::resource("/find_by_exercise_id/{ex_id}/")
                         .route(web::get().to(set::find_by_exercise_id))
                 )
+                .service(
+                    web::resource("/find_by_set_id/{id}/")
+                        .route(web::get().to(set::find_by_set_id))
+                )
         )
         .route("/", web::get().to(index))
         .route("/{name}/index.html", web::get().to(index_with_name));

--- a/src/handlers/set.rs
+++ b/src/handlers/set.rs
@@ -47,3 +47,16 @@ pub async fn find_by_exercise_id(ex_id: web::Path<i32>) -> impl Responder {
             HttpResponse::InternalServerError().json(e.to_string())
         })
 }
+
+/// Get a json object of a Set from its ID.
+///
+/// More information [here](https://github.com/coloradocollective/DED_Backend/wiki/endpoint-sets-find)
+pub async fn find_by_set_id(id: web::Path<i32>) -> impl Responder {
+    let conn = establish_connection().get().unwrap();
+
+    Set::get_set_by_id(*id, &conn)
+        .map(|set| HttpResponse::Ok().json(set))
+        .map_err(|e| {
+            HttpResponse::InternalServerError().json(e.to_string())
+        })
+}

--- a/src/models/sets.rs
+++ b/src/models/sets.rs
@@ -61,6 +61,17 @@ impl Set {
     }
 }
 
+impl PartialEq<NewSet> for Set {
+    fn eq(&self, other:& NewSet) -> bool {
+        self.exercise_id == other.exercise_id &&
+        self.style == other.style &&
+        self.unit == other.unit &&
+        self.goal_reps == other.goal_reps &&
+        self.goal_value == other.goal_value &&
+        self.description == other.description
+    }
+}
+
 impl SetList {
     pub fn get_sets_by_exercise_id(
         ex_id: &i32,


### PR DESCRIPTION
This is intended to be merged into master after #13 has been merged & the PR will be changed to reflect that.

Major changes:
* ability to compare a Set and a NewSet against each other. /get_sets_exercise_id...get_sets_by_id?expand=1#diff-9a01746ef60e663a36d3c3b8d2b949d1R64)
* handler has been added for `find_by_set_id`.
* test has been created to verify that the data inputted into the database matches the output. 