### PR TITLE
Enable CORS for all origins

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DATABASE_URL=postgres://alex:@localhost/postgres

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://alex:@localhost/postgres

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ gen
 .nfs*
 
 *.swp
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 actix-web = "2"
 actix-rt = "1"
 actix-identity = "0.2"
+actix-cors = "0.2"
 
 diesel = { version = "1.4.3", features = ["postgres","r2d2"] }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use actix_web::{App, HttpServer};
+use actix_cors::Cors;
 use actix_identity::{CookieIdentityPolicy, IdentityService};
 
 use DED_backend::appconfig::config_app;
@@ -18,6 +19,9 @@ async fn main() -> std::io::Result<()> {
                     .name("ded_auth")
                     .secure(false)
                 )
+        )
+        .wrap(
+            Cors::new().supports_credentials().finish()
         )})
         .bind("127.0.0.1:8080")?
         .run()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate dotenv;
 extern crate argonautica;
 extern crate actix_web;
 extern crate actix_identity;
+extern crate actix_cors;
 
 
 


### PR DESCRIPTION
This fixes an issue with AJAX requests to the API being rejected due to CORS (Cross-Origin Resource Sharing) not being enabled server-side.